### PR TITLE
Add repo URL to Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": {
+    "url": "git@github.com:jdaviderb/ember-axios.git"
+  },
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
Adding `url` repo to package.json so `emberobserver` can include it within the addon info